### PR TITLE
Version update in site-counts.php and numerous changes in the Block.php

### DIFF
--- a/site-counts.php
+++ b/site-counts.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Site Counts
  * Description: Post and term counts for your WordPress site.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: XWP
  * Author URI: https://github.com/xwp/site-counts
  * Text Domain: site-counts


### PR DESCRIPTION
In site-counts.php
------------------
updated the version to 1.0.1

In Block.php
------------
added the types for the function call properties
added the type string for the @return  parameter
used $post_type_objects = get_post_types( $args, $output ); call in order to obtain the post types as objects
NOTE: I have intentionally choose to get the post type objects as from the Object I was able to get the post name that I will use later on with WP_Query  (it's more reusable like this)

in first query I have used those properties to optimize it for the performance
'update_post_meta_cache' => false,
'update_post_term_cache' => false,

for the attachment type  used $args['post_status'] = 'inherit';

In order to make sure that we don't loose performance with calling the queries each time I have stored the post counts for the each post type in transient with set_transient( $cache_key, $post_count, 31536000 );. Every time when the page with load this block I am checking if the transient for the number of posts exists and if exists we don't do the query.
NOTE: Since in the instructions it's said that we should only work on the "Please only make changes to the render_callback() function," the final solution would be that we update those transients when any type of post has been added. That can be done with wp_insert_post (using the check for auto-draft) and  delete_post() actions.

For displaying the post I have used the  get_the_ID() as there is no need to use the $_GET['post_id'] for this purpose.

used the localization functions for all strings and one example where there is a comment for the translators  Query for displaying the 5 posts is optimized with: posts_per_page'         => 6,  (we are calling the 6 posts but will make sure to display only 5) later in the code as we don't want to display the current post

added those 2 for query optimization
'update_post_meta_cache' => false,
'include_children'       => false,

taken out the  'post__not_in' => [ get_the_ID() ], as it's not good for performance and

used ! in_array( $current, $posts_to_exclude, true in PHP code bellow

added the link in  the_tile function the_title( '<li><a href="' . get_permalink() . '">', '</a></li>' ); as there is no point of displaying the  posts and not having links back to them
NOTE: in the real life case I would consult the client before making this change